### PR TITLE
Tatt bort siste siffer av versjonsnummeret fra tittelen

### DIFF
--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -1,5 +1,5 @@
 include::locale/attributes.adoc[]
-= Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på TBX (TBX-AP-NO) - Versjon 1.0.1
+= Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på TBX (TBX-AP-NO) - Versjon 1.0
 :description: Forvaltningsstandard for tilgjengeliggjøring av begrepsbeskrivelser basert på TBX (TBX-AP-NO)
 :doctype: book
 :docinfo:


### PR DESCRIPTION
Bare en liten redaksjonell retting: Siste siffer av versjonsnummer nå i tittelen er ikke i samsvar med versjonsnummeret i dokumentet. Det siste sifferet trenger dessuten ikke å stå i tittelen. 