### PR TITLE
develop -> v2

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/adocs-build-v2-and-publish-to-production.yml
+++ b/.github/workflows/adocs-build-v2-and-publish-to-production.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: v2
           submodules: true

--- a/docs/Navnerom.adoc
+++ b/docs/Navnerom.adoc
@@ -15,7 +15,7 @@
 |rdfs | `\http://www.w3.org/2000/01/rdf-schema#` | https://www.w3.org/TR/rdf-schema/[RDF Schema 1.1]
 |skos | `\http://www.w3.org/2004/02/skos/core#` | https://www.w3.org/TR/skos-reference/[SKOS Simple Knowledge Organization System]
 |skosno | `\https://data.norge.no/vocabulary/skosno#`  | https://data.norge.no/specification/skos-ap-no-begrep[Forvaltningsstandard for begrepsbeskrivelser (SKOS-AP-NO-Begrep)]
-|uneskos | `\http://purl.org/umu/uneskos#` | https://skos.um.es/TR/uneskos/[UNESKOS Vocabulary]
+|uneskos | `\http://purl.org/umu/uneskos#` | UNESKOS Vocabulary
 |vcard | `\http://www.w3.org/2006/vcard/ns#` | https://www.w3.org/TR/vcard-rdf/[vCard Ontology - for describing People and Organizations]
 |xkos | `\http://rdf-vocabulary.ddialliance.org/xkos#` | https://rdf-vocabulary.ddialliance.org/xkos.html[An SKOS extension for representing statistical classifications]
 |===

--- a/docs/conceptEntry.adoc
+++ b/docs/conceptEntry.adoc
@@ -150,7 +150,7 @@ Eksempel i TBX-AP-NO (DCT style), for et fiktivt eksempelbegrep:
 |===
 | Navn / _Name_ |inngår i begrepssamling / _member of_
 | Datakategori / _Data category_ |uneskos:memberOf
-| PID |https://skos.um.es/TR/uneskos/#memberOf[https://skos.um.es/TR/uneskos/#memberOf]
+| PID | \http://purl.org/umu/uneskos#memberOf
 | TBX-nivå / _TBX level_ |conceptEntry
 | TBX-klassifisering / _TBX Classification_ |admin
 | Verdiområde / _Range_ |ref or xref

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -16,9 +16,9 @@ ifdef::backend-pdf[:toc: macro]
 image::images/Digdir.png[width=50%, pdfwidth=30vw, link=https://digdir.no/]
 
 *Status*: Gjeldende +
-*Versjon*: 2.0.3 +
+*Versjon*: 2.0.4 +
 *Publisert*: 2022-12-09 (v.2.0.0) +
-*Oppdatert*: 2023-10-24 (v.2.0.x, se <<Endringslogg, endringslogg>>) +
+*Oppdatert*: 2025-08-22 (v.2.0.x, se <<Endringslogg, endringslogg>>) +
 *Gjeldende versjon*: https://data.norge.no/specification/tbx-ap-no/ +
 *Forrige versjon*: https://data.norge.no/specification/tbx-ap-no/v1 + 
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/tbx-ap-no/ +


### PR DESCRIPTION
For å få de siste endringene (å rette opp brutte lenker) fra develop til v2 (og dermed data.norge.no)