### PR TITLE
chore: use reusable specification workflows

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -1,5 +1,8 @@
 name: build adocs develop and publish to GitHub pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -8,42 +11,17 @@ on:
       - docs/**
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pages: write
-
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/tbx-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy to GitHub pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+  build-adocs:
+    name: Build and deploy to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      ref: develop
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/tbx-ap-no.pdf -a lang=nb docs/main.adoc
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-v2-and-publish-to-production.yml
+++ b/.github/workflows/adocs-build-v2-and-publish-to-production.yml
@@ -1,5 +1,8 @@
 name: Build adocs and publish v2 to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,52 +11,25 @@ on:
       - "docs/**"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/tbx-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "tbx-ap-no"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/tbx-ap-no.pdf application/pdf nb files/tbx-ap-no.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/TBX-AP-NO_Begrepssamling.png image/png nb images/TBX-AP-NO_Begrepssamling.png
-            docs/images/TBX-AP-NO_conceptEntry.png image/png nb images/TBX-AP-NO_conceptEntry.png
-            docs/images/TBX-AP-NO_langSec.png image/png nb images/TBX-AP-NO_langSec.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/tbx-ap-no.pdf -a lang=nb docs/main.adoc
+      files: |
+        docs/index.html text/html nb
+        docs/files/tbx-ap-no.pdf application/pdf nb files/tbx-ap-no.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/TBX-AP-NO_Begrepssamling.png image/png nb images/TBX-AP-NO_Begrepssamling.png
+        docs/images/TBX-AP-NO_conceptEntry.png image/png nb images/TBX-AP-NO_conceptEntry.png
+        docs/images/TBX-AP-NO_langSec.png image/png nb images/TBX-AP-NO_langSec.png
+      host: https://fellesdatakatalog.digdir.no
+      ontology: tbx-ap-no
+      ontology-type: specification
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary

Migrate both AsciiDoc build/publish workflows to the central Informasjonsforvaltning/workflows reusable workflows.

- adocs-build-develop.yml now calls specification-github-pages.yaml@main
- adocs-build-v2-and-publish-to-production.yml now calls specification-upload-files.yaml@main
- Closes #76 — removes abandoned Analog-inc/asciidoctor-action; all third-party actions are SHA-pinned inside the reusable workflow (also bumps upload action to v3.3.0)
- Closes #78 — pins ref (develop/v2) so workflow_dispatch can't publish arbitrary branch state
- Triggers preserved verbatim